### PR TITLE
Set indexed default value for all fields at schema options level

### DIFF
--- a/lib/schema/builders/schema-builder.ts
+++ b/lib/schema/builders/schema-builder.ts
@@ -32,7 +32,7 @@ export default abstract class SchemaBuilder<TEntity extends Entity> {
   }
 
   protected buildIndexed(field: BaseFieldDefinition) {
-    return field.indexed ?? true ? [] : ['NOINDEX']
+    return field.indexed ?? this.schema.indexedDefault ? [] : ['NOINDEX']
   }
 
   protected buildStemming(field: StemmingFieldDefinition) {

--- a/lib/schema/definition/base-field-definition.ts
+++ b/lib/schema/definition/base-field-definition.ts
@@ -13,7 +13,7 @@ interface BaseFieldDefinition {
 
   /**
    * Is this field indexed and thus searchable with Redis OM. Defaults
-   * to true.
+   * to the schema indexedDefault value, currently true.
    */
   indexed?: boolean;
 }

--- a/lib/schema/options/schema-options.ts
+++ b/lib/schema/options/schema-options.ts
@@ -54,6 +54,11 @@ type SchemaOptions = {
    * anything other than `CUSTOM`, this option is ignored.
    */
   stopWords?: Array<string>
+
+  /**
+   * Whether fields are indexed by default
+   */
+  indexedDefault?: boolean
 }
 
 export default SchemaOptions;

--- a/lib/schema/schema.ts
+++ b/lib/schema/schema.ts
@@ -96,6 +96,11 @@ export default class Schema<TEntity extends Entity> {
    */
   get stopWords(): Array<string> { return this.options?.stopWords ?? []; }
 
+  /**
+   * The configured indexed default setting for fields
+   */
+  get indexedDefault(): boolean { return this.options?.indexedDefault ?? true; }
+
   /** The hash value of this index. Stored in Redis under {@link Schema.indexHashName}. */
   get indexHash(): string {
 


### PR DESCRIPTION
Experiment to make it easier to change the `indexed` default setting for fields by allowing the default value for fields to be set at the schema options level. i.e. if the default was changed so that fields were _not_ indexed by default, the previous behaviour could be more easily restored by adding one line to the options:

```
const albumSchema = new Schema(Album, {
  artist: { type: 'string' },
  title: { type: 'string' },
  year: { type: 'number' },
  genres: { type: 'string[]' },
  outOfPublication: { type: 'boolean' }
}, {
  dataStructure: 'HASH',
  indexedDefault: true,
})
```

Whatever default was set, individual fields could still override it, so it may be useful in it's own right if you want all but a few fields to be indexed or vice-versa.

This change is from the branch for https://github.com/redis/redis-om-node/pull/81

Another option if it's use was temporary would be to introduce some global setting for redis-om, maybe an import than triggers the previous behaviour.